### PR TITLE
CI CD revision

### DIFF
--- a/src/continuous-deployment.tex
+++ b/src/continuous-deployment.tex
@@ -1,7 +1,23 @@
-Continuous deployment is the step after continuous integration finishes, namely the deployment or archive of build artifacts for use in production. 
-For DevOps, this typically means pushing containers to a registry where they can be pulled to some production or testing environment.
+Continuous deployment is the step after continuous integration finishes, namely
+the deployment or archive of build artifacts for use in production.  For
+DevOps, this typically means pushing containers to a registry where they can be
+pulled to some production or testing environment.
 
-On HPC the software is optimally installed on bare metal instead of relying on containers or some kind of container orchestrator. For HPC it's also up to workload managers \cite{slurm,flux} to run the software. These resources are also typically protected, and not easily accessible from a web interface.
+On HPC the software is optimally installed on bare metal instead of relying on
+containers or some kind of container orchestrator. For HPC it's also up to
+workload managers \cite{slurm,flux} to run the software. These resources are
+also typically protected, and not easily accessible from a web interface.
 
-For RSE-ops on HPC, a similar approach using containers could be adopted, however due to the private nature of software it could be that registries and services are internal. A self-deployed CI service (e.g., Jenkins or GitLab \cite{jenkins,gitlab}) that has access to cluster resources could either deploy an artifact or use SSH to execute a command to do similar. A container could be pushed to an open source or internal registry. One important question that results from this is how to control access and security. If a user builds a container in CI, how is it assessed or scanned to be safe to deploy?  There is also one additional level of complexity with providing containers with different architectures to run
-optimally on the system. Finally, build caches (meaning binary packages) would be an equally good solution, or in fact a supplement. Build caches are ideal for reuse, and containers for reproducibility.
+For RSE-ops on HPC, a similar approach using containers could be adopted,
+however due to the private nature of software it could be that registries and
+services are internal. A self-deployed CI service (e.g., Jenkins or GitLab
+\cite{jenkins,gitlab}) that has access to cluster resources could either deploy
+an artifact or use SSH to execute a command to do similar. A container could be
+pushed to an open source or internal registry. One important question that
+results from this is how to control access and security. If a user builds a
+container in CI, how is it assessed or scanned to be safe to deploy?  There is
+also one additional level of complexity with providing containers with
+different architectures to run optimally on the system. Finally, build caches
+(meaning binary packages) would be an equally good solution, or in fact a
+supplement. Build caches are ideal for reuse, and containers for
+reproducibility.

--- a/src/continuous-deployment.tex
+++ b/src/continuous-deployment.tex
@@ -1,23 +1,32 @@
-Continuous deployment is the step after continuous integration finishes, namely
-the deployment or archive of build artifacts for use in production.  For
-DevOps, this typically means pushing containers to a registry where they can be
-pulled to some production or testing environment.
+Similarly to Continuous integration, continuous deployment (or delivery) is the
+effort to distribute a production ready software as often as possible. This
+could take the form of tagged version in the code base, source archive, binary,
+or container releases. Continuous delivery aims at minimizing the down-time
+between a failure of the product, and the release of the fix.
 
-On HPC the software is optimally installed on bare metal instead of relying on
-containers or some kind of container orchestrator. For HPC it's also up to
-workload managers \cite{slurm,flux} to run the software. These resources are
-also typically protected, and not easily accessible from a web interface.
+In the DevOps culture, deploying containers is becoming a standard. It allows
+for optimal interchangebility, fast roll-backs, and even leads to the trend
+to organize the software stack as micro-services.
 
-For RSE-ops on HPC, a similar approach using containers could be adopted,
-however due to the private nature of software it could be that registries and
+On HPC the software is configured and built to run on bare metal instead of
+relying on generic releases. In practice, we can classify HPC software in two
+categories: The cluster software stack is typically installed by the admins,
+carefully tuned to acheive stability and performance, with a limited number of
+variants of a same product. Scientific code and libraries are most likely
+compiled and installed by the final users relying on a configuration often
+specific to the simulation code: most installation can be considered unique.
+
+Even in HPC, an approach based on containers could be adopted, however due to
+the private nature of scientific software it could be that registries and
 services are internal. A self-deployed CI service (e.g., Jenkins or GitLab
 \cite{jenkins,gitlab}) that has access to cluster resources could either deploy
 an artifact or use SSH to execute a command to do similar. A container could be
-pushed to an open source or internal registry. One important question that
-results from this is how to control access and security. If a user builds a
-container in CI, how is it assessed or scanned to be safe to deploy?  There is
-also one additional level of complexity with providing containers with
-different architectures to run optimally on the system. Finally, build caches
-(meaning binary packages) would be an equally good solution, or in fact a
-supplement. Build caches are ideal for reuse, and containers for
-reproducibility.
+pushed to an open source or internal registry.
+
+One important question that results from this is how to control access and
+security. If a user builds a container in CI, how is it assessed or scanned to
+be safe to deploy?  There is also one additional level of complexity with
+providing containers with different architectures to run optimally on the
+system. Finally, build caches (meaning binary packages) would be an equally
+good solution, or in fact a supplement. Build caches are ideal for reuse, and
+containers for reproducibility.

--- a/src/continuous-integration.tex
+++ b/src/continuous-integration.tex
@@ -1,40 +1,43 @@
-Continuous integration is an established practice of continually testing and
-building before deployment.  It typically is focused around a version
-controlled code-base (e.g., GitHub or GitLab \cite{github,gitlab}) and
-developers collaborate to review code, ensure that tests pass, and then merge
-into a main branch. The goals are generally to ensure that when a piece or
-software or service hits a production resource, there will be no bugs or
-errors. Artifacts can be built and deployed on an event such as a merge, or for
-a versioned release. The benefits of CI practices are obvious, allowing
-developers to more easily collaborate on a code-base, and interact with
-production artifacts on resources of interest. For DevOps this typically
-includes different container orchestration services, instances, or app
-deployments, and for RSE-ops this would likely mean a local server or HPC
-cluster. The version control system also typically provides an interface to
-make it easy to report and respond to bugs (typically called issues) along with
-making suggestions to improve code (called pull or merge requests) and tracking
-progress.  This kind of workflow fits well into any DevOps environment where
-change is a constant.
+Continuous integration is the effort to continually test and build the codebase
+while it is being changed by developers. The rationale being: the earlier the
+code is tested, the earlier we catch bugs and new changes can be integrated.
+"Continously" integrating is of course out of reach, but it is commonly
+accepted as a metric of how agile the code team is.
 
-In the context of HPC, the diversity of resources that codes need to run on
-proves to be a much larger challenge for CI. The most popular, public CI
-services are not designed to interact with a batch system. It typically isn't
-sufficient to just test on a standard Linux x64, Mac, and Windows architecture,
-but several architectures across different operating systems (primarily Linux)
-that reflect the variety of the cluster nodes. The first challenge this
-presents is that most standard, web-based CI services (e.g., GitHub actions
-runners, standard GitLab runners, TravisCI, Jenkins, and CircleCI) don't
-provide a rich variety of architectures or graphical processing units (GPU), or
-when they do, they don't provide much control of when you get them.
+Integrating changes continuously requires automated testing, and contributions
+of small sizes so that they can be reviewed quickly and remain easy to
+understand. Those are means to CI, but can be viewed as goals by themselves.
 
-For this reason, for research software we typically see the developers still
-develop using these systems, but then are not able to test on all the systems
-that might be needed.  The challenge is thus getting any kind of modern
-web-based interface linked up directly to a cluster to run tests. Work at
-national labs using GitLab \cite{Mendoza_undated-lz,noauthor_undated-fv}, and
-specifically having a locally deployed Gitlab server with custom runners on
-various resources \cite{noauthor_undated-jd} has been a way to unite these two
-worlds.  Managing such an integration requires thinking about how to manage
-resources, user accounts, time allocations, and machine access. Another
-challenge is that there is is no standard workflow language for CI, and perhaps
-there should be.
+Reviews form a typical bottleneck to continuous integration: it is the
+last manual part of the process. This is why it is key to make reviews as
+streamlined as possible. This means in particular: Automated testing should
+capture as much relevant information as possible ( code style compliance,
+compiling in various contexts, unit-testing and testing with high coverage).
+Test results should be displayed intelligibly, the reviewer needs to have
+confidence that the report is comprehensive. Reproducing tests and the new
+feature should be straightforward.
+
+In the DevOps culture this implies working with container orchestration
+services. In the context of HPC, the diversity of systems that codes need to
+run on turns into a challenge for CI. It is useful yet insufficient to just
+test on a standard Linux x64, Mac, and Windows architecture. Most public CI
+services are not designed to interact with a batch system. One solution is to
+registering a local server or HPC cluster in the CI service provider, with the
+caveat that those cluster come with security requirements that often forbit it.
+
+For this reason, research software development may happen on any of these
+exotic systems but then testing is rather limited. Work at national labs using
+GitLab \cite{Mendoza_undated-lz,noauthor_undated-fv}, and specifically having a
+locally deployed Gitlab server with custom runners on various resources
+\cite{noauthor_undated-jd} has been a way to bridge the gap between HPC centers
+and web-based CI service providers. Managing this infrastructure requires
+managing resources, user accounts, time allocations, and machine access, and
+a lot of work has been dedicated to match the security requirements.
+
+Another challenge is that there is no standard workflow language for CI.
+After the realization that infrastructure-as-code (using a text based, version
+controlled workflow implementation) is more maintainable that UI configured CI,
+the consensus was that YAML provided a convenient format to implement CI, but
+languages varies between CI providers. Best practice suggest keeping scripts
+outside of the YAML implementation to allow for easier translation between
+languages.

--- a/src/continuous-integration.tex
+++ b/src/continuous-integration.tex
@@ -1,9 +1,40 @@
-Continuous integration is an established practice of continually testing and building before deployment.
-It typically is focused around a version controlled code-base (e.g., GitHub or GitLab \cite{github,gitlab}) and developers collaborate to review code, ensure that tests pass, and then merge into a main branch. The goals are generally to ensure that when a piece or software or service hits a production resource, there will be no bugs or errors. Artifacts can be built and deployed on an event such as a merge, or for a versioned release. The benefits of CI practices are obvious, allowing developers to more easily collaborate on a code-base, and interact with production artifacts on resources of interest. For DevOps this typically includes different container orchestration services, instances, or app deployments, and for RSE-ops this would likely mean a local server or HPC cluster. The version control system also typically provides an interface to make it easy to report and respond to bugs (typically called issues) along with making suggestions to improve code (called pull or merge requests) and tracking progress.
-This kind of workflow fits well into any DevOps environment where change is a constant.
+Continuous integration is an established practice of continually testing and
+building before deployment.  It typically is focused around a version
+controlled code-base (e.g., GitHub or GitLab \cite{github,gitlab}) and
+developers collaborate to review code, ensure that tests pass, and then merge
+into a main branch. The goals are generally to ensure that when a piece or
+software or service hits a production resource, there will be no bugs or
+errors. Artifacts can be built and deployed on an event such as a merge, or for
+a versioned release. The benefits of CI practices are obvious, allowing
+developers to more easily collaborate on a code-base, and interact with
+production artifacts on resources of interest. For DevOps this typically
+includes different container orchestration services, instances, or app
+deployments, and for RSE-ops this would likely mean a local server or HPC
+cluster. The version control system also typically provides an interface to
+make it easy to report and respond to bugs (typically called issues) along with
+making suggestions to improve code (called pull or merge requests) and tracking
+progress.  This kind of workflow fits well into any DevOps environment where
+change is a constant.
 
-In the context of HPC, the diversity of resources that codes need to run on proves to be a much larger challenge for CI. The most popular, public CI services are not designed to interact with a batch system. It typically isn't sufficient to just test on a standard Linux x64, Mac, and Windows architecture, but several architectures across different operating systems (primarily Linux) that reflect the variety of the cluster nodes. The first challenge this presents is that most standard, web-based CI services (e.g., GitHub actions runners, standard GitLab runners, TravisCI, Jenkins, and CircleCI) don't provide a rich variety of architectures or graphical processing units (GPU), or when they do, they don't provide much control of when you get them.
+In the context of HPC, the diversity of resources that codes need to run on
+proves to be a much larger challenge for CI. The most popular, public CI
+services are not designed to interact with a batch system. It typically isn't
+sufficient to just test on a standard Linux x64, Mac, and Windows architecture,
+but several architectures across different operating systems (primarily Linux)
+that reflect the variety of the cluster nodes. The first challenge this
+presents is that most standard, web-based CI services (e.g., GitHub actions
+runners, standard GitLab runners, TravisCI, Jenkins, and CircleCI) don't
+provide a rich variety of architectures or graphical processing units (GPU), or
+when they do, they don't provide much control of when you get them.
 
-For this reason, for research software we typically see the developers still develop using these systems, but then are not able to test on all the systems that might be needed.
-The challenge is thus getting any kind of modern web-based interface linked up directly to a cluster to run tests. Work at national labs using GitLab \cite{Mendoza_undated-lz,noauthor_undated-fv}, and specifically having a locally deployed Gitlab server with custom runners on various resources \cite{noauthor_undated-jd} has been a way to unite these two worlds.
-Managing such an integration requires thinking about how to manage resources, user accounts, time allocations, and machine access. Another challenge is that there is is no standard workflow language for CI, and perhaps there should be.
+For this reason, for research software we typically see the developers still
+develop using these systems, but then are not able to test on all the systems
+that might be needed.  The challenge is thus getting any kind of modern
+web-based interface linked up directly to a cluster to run tests. Work at
+national labs using GitLab \cite{Mendoza_undated-lz,noauthor_undated-fv}, and
+specifically having a locally deployed Gitlab server with custom runners on
+various resources \cite{noauthor_undated-jd} has been a way to unite these two
+worlds.  Managing such an integration requires thinking about how to manage
+resources, user accounts, time allocations, and machine access. Another
+challenge is that there is is no standard workflow language for CI, and perhaps
+there should be.


### PR DESCRIPTION
This is a proposed revision of both the Continuous Integration and the Continuous Deployment sections.

Takeaways:
- I first limited the number of characters per line. The text was not readable in most interfaces (github, editor) and diffing was just impossible.
- I wasn’t planning on changing that much on the text, but I think I am proposing an improvement, otherwise I wouldn't have done it.
- In both cases, I tried to make CI and CD definitions more accurate and concise.
- I don't think RSE-Ops is good name. Ops stands for operation, and is typically the part of "Dev(Sec)Ops" that needs to be redefined the most for HPC. Also "Research Software" is very, very generic and could cover HPC tools and codes (as in this document), but also anything from operation software toolchain at NIF, web utilities, whatever python tool, many things. That's why I think specifically targeting HPC here is both more specific, and more reasonable. (It is likely that DevOps applies out of the box to a subset of all the research softwares).
- I typically added some content in the challenge sections in CI. This is why this section is not shorter in this proposal.
- I am not done with the second half of CD, partly because I am not familiar with containers, and I was not able to extract the challenge more concisely, while putting this in the context of CD. Basically, I agree containerization is a challenge, but not exactly or not only in the context of Continuous Delivery. So maybe this would deserve a dedicated section.